### PR TITLE
Replace log callback with AtualizarStatusProgresso

### DIFF
--- a/Form_Tela_Principal.cs
+++ b/Form_Tela_Principal.cs
@@ -104,7 +104,7 @@ namespace INSTALADOR_SOFTWARE_SE
             }
             catch (Exception ex)
             {
-                _logCallback($"ERRO ao ler master_config.json: {ex.Message}");
+                AtualizarStatusProgresso($"ERRO ao ler master_config.json: {ex.Message}");
                 return null;
             }
         }


### PR DESCRIPTION
## Summary
- swap log call in `CarregarConfiguracoesDaRede` to use `AtualizarStatusProgresso`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c28dfa958832897f1baeefa3321bf