### PR TITLE
Add Windows Forms using for Application

### DIFF
--- a/Helpers/GerenciadorDeEstado.cs
+++ b/Helpers/GerenciadorDeEstado.cs
@@ -1,6 +1,7 @@
 using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
+using System.Windows.Forms;
 
 namespace INSTALADOR_SOFTWARE_SE.Helpers
 {


### PR DESCRIPTION
## Summary
- fix Application.ExecutablePath reference by including `System.Windows.Forms`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c28eee750832895882a255c4706bb