### PR TITLE
Add DeploymentShare scripts and config examples

### DIFF
--- a/DeploymentShare$/Applications/HelpDeskSystem_v2.1.msi
+++ b/DeploymentShare$/Applications/HelpDeskSystem_v2.1.msi
@@ -1,0 +1,1 @@
+Placeholder for HelpDeskSystem installer

--- a/DeploymentShare$/Applications/LegacyAccessTool_Setup.exe
+++ b/DeploymentShare$/Applications/LegacyAccessTool_Setup.exe
@@ -1,0 +1,1 @@
+Placeholder for Legacy Access Tool installer

--- a/DeploymentShare$/Applications/VPN/OpenVPN_2.5.msi
+++ b/DeploymentShare$/Applications/VPN/OpenVPN_2.5.msi
@@ -1,0 +1,1 @@
+Placeholder for OpenVPN installer

--- a/DeploymentShare$/Config/Hosts/hosts.desenvolvimento
+++ b/DeploymentShare$/Config/Hosts/hosts.desenvolvimento
@@ -1,0 +1,7 @@
+# HOSTS personalizado para ambiente de desenvolvimento
+127.0.0.1   api.dev.local
+127.0.0.1   auth.dev.local
+127.0.0.1   database.dev.local
+192.168.10.50   portal.staging.sepromotora.local
+192.168.10.51   api.staging.sepromotora.local
+192.168.10.52   reports.staging.sepromotora.local

--- a/DeploymentShare$/Config/VPN/config_ti_dev.ovpn
+++ b/DeploymentShare$/Config/VPN/config_ti_dev.ovpn
@@ -1,0 +1,17 @@
+client
+proto udp
+remote vpn.sepromotora.local 1194
+resolv-retry infinite
+nobind
+auth-nocache
+cipher AES-256-CBC
+verb 3
+<ca>
+# Certificado da autoridade certificadora aqui
+</ca>
+<cert>
+# Certificado do cliente aqui
+</cert>
+<key>
+# Chave privada do cliente aqui
+</key>

--- a/DeploymentShare$/Config/master_config.json
+++ b/DeploymentShare$/Config/master_config.json
@@ -1,17 +1,67 @@
 {
   "unidades": [
-    { "nomeExibicao": "Matriz (Ingressar no Domínio)", "id": "matriz" },
-    { "nomeExibicao": "Filial - SE", "id": "filial_se" },
-    { "nomeExibicao": "Filial - BA (Expansão)", "id": "filial_ba" }
+    {
+      "nomeExibicao": "Matriz (Ingressar no Domínio)",
+      "id": "matriz",
+      "namingPrefix": "sepro"
+    },
+    {
+      "nomeExibicao": "Filial - Sergipe",
+      "id": "filial_se",
+      "namingPrefix": "se-se"
+    },
+    {
+      "nomeExibicao": "Filial - Bahia (Expansão)",
+      "id": "filial_ba",
+      "namingPrefix": "se-ba"
+    },
+    {
+      "nomeExibicao": "Standalone (Sem Domínio)",
+      "id": "standalone",
+      "namingPrefix": "st-pc"
+    }
   ],
   "setores": [
-    { "nomeExibicao": "TI - Tecnologia", "id": "ti" },
-    { "nomeExibicao": "Financeiro", "id": "financeiro" },
-    { "nomeExibicao": "Vendas", "id": "vendas" }
+    {
+      "nomeExibicao": "TI - Tecnologia",
+      "id": "ti"
+    },
+    {
+      "nomeExibicao": "Financeiro",
+      "id": "financeiro"
+    },
+    {
+      "nomeExibicao": "Vendas e Comercial",
+      "id": "vendas"
+    },
+    {
+      "nomeExibicao": "Recursos Humanos",
+      "id": "rh"
+    },
+    {
+      "nomeExibicao": "Operacional Padrão",
+      "id": "operacional"
+    }
   ],
   "usuariosFinais": [
-    { "nomeExibicao": "Augusto Santos - TI", "loginName": "augusto.santos" },
-    { "nomeExibicao": "Maria Oliveira - Financeiro", "loginName": "maria.oliveira" },
-    { "nomeExibicao": "João Pereira - Vendas", "loginName": "joao.pereira" }
-  ]
-}
+    {
+      "nomeExibicao": "Augusto Santos - TI",
+      "loginName": "augusto.santos"
+    },
+    {
+      "nomeExibicao": "Maria Oliveira - Financeiro",
+      "loginName": "maria.oliveira"
+    },
+    {
+      "nomeExibicao": "João Pereira - Vendas",
+      "loginName": "joao.pereira"
+    },
+    {
+      "nomeExibicao": "Ana Costa - RH",
+      "loginName": "ana.costa"
+    },
+    {
+      "nomeExibicao": "Carlos Souza - Operacional",
+      "loginName": "carlos.souza"
+    }
+  ]}

--- a/DeploymentShare$/Config/matriz_financeiro.json
+++ b/DeploymentShare$/Config/matriz_financeiro.json
@@ -1,0 +1,22 @@
+{
+  "nomePerfil": "Matriz - Financeiro",
+  "wingetPackages": [
+    "Adobe.Acrobat.Reader.64-bit",
+    "Google.Chrome"
+  ],
+  "legacyInstallers": [
+    {
+      "nome": "Sistema Financeiro Legacy",
+      "path": "\\seu-servidor\\DeploymentShare$\\Applications\\FinanceSystem_v1.0.msi",
+      "tipo": "msi",
+      "argumentos": "/qn /norestart"
+    }
+  ],
+  "printers": [
+    "\\servidor-impressao\\IMP_FIN_CONTABIL",
+    "\\servidor-impressao\\IMP_FIN_ETIQUETAS"
+  ],
+  "localGroups": [
+    "Remote Desktop Users"
+  ]
+}

--- a/DeploymentShare$/Config/matriz_ti.json
+++ b/DeploymentShare$/Config/matriz_ti.json
@@ -1,32 +1,46 @@
 {
-  "setor": "TI - Tecnologia",
-  "winget_packages": [
+  "nomePerfil": "Matriz - Padrão de TI",
+  "wingetPackages": [
     "Microsoft.VisualStudioCode",
     "Docker.DockerDesktop",
-    "Postman.Postman"
+    "Postman.Postman",
+    "7zip.7zip",
+    "Microsoft.WindowsTerminal",
+    "Git.Git",
+    "Microsoft.PowerToys",
+    "ShareX.ShareX"
   ],
-  "legacy_installers": [
+  "legacyInstallers": [
     {
-      "name": "Sistema Interno de Chamados",
-      "path": "\\seu-servidor\\DeploymentShare$\\Applications\\HelpDeskSystem.msi",
-      "type": "msi",
-      "args": "/qn /norestart"
+      "nome": "Sistema Interno de Chamados (HelpDesk Admin Console)",
+      "path": "\\seu-servidor\\DeploymentShare$\\Applications\\HelpDeskSystem_Admin_v2.1.msi",
+      "tipo": "msi",
+      "argumentos": "/qn /norestart"
     },
     {
-      "name": "Ferramenta de Acesso Legado",
-      "path": "\\seu-servidor\\DeploymentShare$\\Applications\\LegacyAccessTool.exe",
-      "type": "exe",
-      "args": "/S /VERYSILENT"
+      "nome": "Cliente de Banco de Dados Oracle (SQL Developer)",
+      "path": "\\seu-servidor\\DeploymentShare$\\Applications\\OracleClient_Setup.exe",
+      "tipo": "exe",
+      "argumentos": "/S /VERYSILENT /NORESTART"
     },
     {
-      "name": "Script de Configuração de Rede",
-      "path": "\\seu-servidor\\DeploymentShare$\\Scripts\\ConfigureVlan-TI.bat",
-      "type": "bat",
-      "args": ""
+      "nome": "Script de Mapeamento de Pastas de Rede - TI",
+      "path": "\\seu-servidor\\DeploymentShare$\\Scripts\\Map-TI-Drives.bat",
+      "tipo": "bat",
+      "argumentos": ""
     }
   ],
   "printers": [
-    "\\servidor-impressao\IMP_TI_01",
-    "\\servidor-impressao\PLOTTER_PROJETOS"
-  ]
-}
+    "\\servidor-impressao\\IMP_TI_COLOR_A3",
+    "\\servidor-impressao\\PLOTTER_PROJETOS_HP"
+  ],
+  "hostsFile": "hosts.desenvolvimento",
+  "vpnConfig": {
+    "installerPath": "\\seu-servidor\\DeploymentShare$\\Applications\\VPN\\OpenVPN_2.5.8_amd64.msi",
+    "configFilePath": "\\seu-servidor\\DeploymentShare$\\Config\\VPN\\config_ti_dev.ovpn"
+  },
+  "localGroups": [
+    "Remote Desktop Users",
+    "Hyper-V Administrators",
+    "Administrators"
+  ]}

--- a/DeploymentShare$/Scripts/Add-NetworkPrinters.ps1
+++ b/DeploymentShare$/Scripts/Add-NetworkPrinters.ps1
@@ -1,0 +1,26 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [string[]]$PrinterPaths
+)
+
+Write-Host "Iniciando processo de adição de impressoras de rede..."
+
+if (-not $PrinterPaths) {
+    Write-Host "Nenhum caminho de impressora foi fornecido. Encerrando o script."
+    exit 0
+}
+
+foreach ($path in $PrinterPaths) {
+    try {
+        if (-not ($path.StartsWith("\\"))) { throw "O caminho '$path' não parece ser um caminho de rede UNC válido (deve começar com \\)." }
+        Write-Host "Tentando conectar e instalar a impressora em: $path"
+        Add-Printer -ConnectionName $path -ErrorAction Stop
+        Write-Host "Impressora '$path' adicionada com sucesso."
+    } catch {
+        Write-Warning "AVISO: Falha ao adicionar a impressora '$path'. Erro: $($_.Exception.Message)"
+    }
+}
+
+Write-Host "Processo de adição de impressoras concluído. Verifique os avisos acima para qualquer falha."
+exit 0

--- a/DeploymentShare$/Scripts/Add-UserToLocalGroups.ps1
+++ b/DeploymentShare$/Scripts/Add-UserToLocalGroups.ps1
@@ -1,0 +1,37 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$UserName,
+    [Parameter(Mandatory=$true)]
+    [string[]]$GroupNames,
+    [string]$DomainName = "SEPROMOTORA"
+)
+
+$fullUserName = "$DomainName\$UserName"
+Write-Host "Iniciando processo para adicionar o usuário '$fullUserName' a grupos locais..."
+
+if (-not $GroupNames) {
+    Write-Host "Nenhum grupo foi especificado. Encerrando o script."
+    exit 0
+}
+
+foreach ($groupName in $GroupNames) {
+    try {
+        Write-Host "Processando grupo local: '$groupName'..."
+        $grupoLocal = Get-LocalGroup -Name $groupName -ErrorAction SilentlyContinue
+        if (-not $grupoLocal) { throw "O grupo local '$groupName' não foi encontrado nesta máquina." }
+        $members = Get-LocalGroupMember -Group $groupName
+        if ($members.Name -contains $fullUserName) {
+            Write-Host "O usuário '$fullUserName' já é membro do grupo '$groupName'. Nenhuma ação necessária."
+            continue
+        }
+        Write-Host "Adicionando '$fullUserName' ao grupo '$groupName'..."
+        Add-LocalGroupMember -Group $groupName -Member $fullUserName -ErrorAction Stop
+        Write-Host "Usuário adicionado com sucesso."
+    } catch {
+        Write-Warning "AVISO: Falha ao adicionar usuário ao grupo '$groupName'. Erro: $($_.Exception.Message)"
+    }
+}
+
+Write-Host "Processo de adição a grupos locais concluído."
+exit 0

--- a/DeploymentShare$/Scripts/Finalize-System.ps1
+++ b/DeploymentShare$/Scripts/Finalize-System.ps1
@@ -1,0 +1,26 @@
+[CmdletBinding()]
+param()
+
+try {
+    Write-Host "Iniciando a reativação do Controle de Conta de Usuário (UAC) para os padrões de segurança..."
+    $regPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System"
+    Set-ItemProperty -Path $regPath -Name "EnableLUA" -Value 1 -Force
+    Set-ItemProperty -Path $regPath -Name "ConsentPromptBehaviorAdmin" -Value 5 -Force
+    Set-ItemProperty -Path $regPath -Name "PromptOnSecureDesktop" -Value 1 -Force
+    Write-Host "UAC reativado com sucesso."
+    $setupUser = "SEPROMOTORA"
+    Write-Host "Desabilitando a conta de provisionamento local '$setupUser' por segurança..."
+    $localUser = Get-LocalUser -Name $setupUser -ErrorAction SilentlyContinue
+    if ($localUser) {
+        if ($localUser.Enabled) { Disable-LocalUser -Name $setupUser -ErrorAction Stop; Write-Host "Conta '$setupUser' desabilitada com sucesso." }
+        else { Write-Host "Conta '$setupUser' já estava desabilitada." }
+    } else {
+        Write-Warning "AVISO: A conta de provisionamento '$setupUser' não foi encontrada. Nenhuma ação foi tomada."
+    }
+    Write-Host "Script de finalização do sistema concluído com sucesso."
+    exit 0
+} catch {
+    $errorMessage = "ERRO FATAL durante a finalização do sistema: $($_.Exception.Message)"
+    Write-Error $errorMessage
+    exit 1
+}

--- a/DeploymentShare$/Scripts/Install-VPN.ps1
+++ b/DeploymentShare$/Scripts/Install-VPN.ps1
@@ -1,0 +1,41 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$InstallerPath,
+    [Parameter(Mandatory=$true)]
+    [string]$ConfigFilePath
+)
+
+try {
+    Write-Host "Iniciando processo de instalação e configuração da VPN..."
+    Write-Host "Verificando a existência dos arquivos de origem..."
+    if (-not (Test-Path -Path $InstallerPath -PathType Leaf)) { throw "Arquivo instalador da VPN não encontrado em '$InstallerPath'." }
+    if (-not (Test-Path -Path $ConfigFilePath -PathType Leaf)) { throw "Arquivo de configuração da VPN não encontrado em '$ConfigFilePath'." }
+    Write-Host "Arquivos de origem validados com sucesso."
+    Write-Host "Executando instalador da VPN de forma silenciosa: '$InstallerPath'..."
+    $extension = [System.IO.Path]::GetExtension($InstallerPath).ToLower()
+    if ($extension -eq ".msi") {
+        $arguments = "/i `\"$InstallerPath`\" /qn /norestart"
+        $processo = Start-Process "msiexec.exe" -ArgumentList $arguments -Wait -PassThru
+    } elseif ($extension -eq ".exe") {
+        $arguments = "/S /VERYSILENT /NORESTART"
+        $processo = Start-Process -FilePath $InstallerPath -ArgumentList $arguments -Wait -PassThru
+    } else {
+        throw "Tipo de instalador '$extension' não suportado por este script."
+    }
+    if ($processo.ExitCode -ne 0 -and $processo.ExitCode -ne 3010) { throw "O instalador da VPN terminou com um código de erro: $($processo.ExitCode)." }
+    Write-Host "Instalação do software da VPN concluída."
+    $vpnConfigFolder = Join-Path -Path $env:ProgramFiles -ChildPath "OpenVPN\config"
+    Write-Host "Verificando a pasta de destino da configuração: $vpnConfigFolder"
+    if (-not (Test-Path -Path $vpnConfigFolder)) { Write-Host "Pasta de configuração não encontrada. Criando..."; New-Item -Path $vpnConfigFolder -ItemType Directory -Force }
+    $configFileName = [System.IO.Path]::GetFileName($ConfigFilePath)
+    $destinationFile = Join-Path -Path $vpnConfigFolder -ChildPath $configFileName
+    Write-Host "Copiando arquivo de configuração '$configFileName' para '$destinationFile'..."
+    Copy-Item -Path $ConfigFilePath -Destination $destinationFile -Force -ErrorAction Stop
+    Write-Host "Configuração da VPN concluída com sucesso. O cliente está pronto para uso."
+    exit 0
+} catch {
+    $errorMessage = "ERRO FATAL ao instalar ou configurar a VPN: $($_.Exception.Message)"
+    Write-Error $errorMessage
+    exit 1
+}

--- a/DeploymentShare$/Scripts/Invoke-LenovoSystemUpdate.ps1
+++ b/DeploymentShare$/Scripts/Invoke-LenovoSystemUpdate.ps1
@@ -1,0 +1,19 @@
+[CmdletBinding()]
+param()
+
+try {
+    Write-Host "Iniciando a execução do Lenovo System Update como fallback para instalação de drivers..."
+    $caminhoSystemUpdate = "C:\Program Files (x86)\Lenovo\System Update\tvsu.exe"
+    Write-Host "Verificando se a ferramenta existe em: $caminhoSystemUpdate"
+    if (-not (Test-Path $caminhoSystemUpdate)) { throw "ERRO CRÍTICO: Lenovo System Update não encontrado em '$caminhoSystemUpdate'. Não é possível continuar com a instalação de drivers específicos." }
+    Write-Host "Ferramenta encontrada."
+    $argumentos = "/CM -search A -action INSTALL -includerebootpackages 1,3,4,5 -noicon -noreboot -nolicense"
+    Write-Host "Executando o comando com os seguintes argumentos silenciosos: $argumentos"
+    $processo = Start-Process -FilePath $caminhoSystemUpdate -ArgumentList $argumentos -Wait -PassThru
+    Write-Host "Execução do Lenovo System Update concluída."
+    Write-Host "O processo terminou com o código de saída: $($processo.ExitCode)."
+    exit $processo.ExitCode
+} catch {
+    Write-Error "ERRO FATAL ao executar o Lenovo System Update: $($_.Exception.Message)"
+    exit 1
+}

--- a/DeploymentShare$/Scripts/Invoke-SecureDomainJoin.ps1
+++ b/DeploymentShare$/Scripts/Invoke-SecureDomainJoin.ps1
@@ -1,0 +1,42 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$ComputerNameToJoin,
+    [Parameter(Mandatory=$true)]
+    [string]$PerfilId,
+    [Parameter(Mandatory=$true)]
+    [string]$SetorId,
+    [string]$DomainController = "seu-dc-01.sepromotora.local",
+    [string]$DomainName = "sepromotora.local"
+)
+
+try {
+    Write-Host "Iniciando verificação de pré-requisitos para ingresso no domínio..."
+    if (-not (Test-NetConnection -ComputerName $DomainController -Port 389 -InformationLevel "Quiet")) {
+        throw "Falha na comunicação de rede com o Controlador de Domínio '$DomainController'. Verifique as configurações de rede e firewall."
+    }
+    Write-Host "Conectividade com o Controlador de Domínio '$DomainController' confirmada."
+    $ouPath = "OU=Workstations,DC=sepromotora,DC=local"
+    if ($PerfilId -eq "matriz") {
+        $ouBaseMatriz = "OU=Workstations-Matriz,DC=sepromotora,DC=local"
+        switch ($SetorId) {
+            "ti"         { $ouPath = "OU=TI,$ouBaseMatriz" }
+            "financeiro" { $ouPath = "OU=Financeiro,$ouBaseMatriz" }
+            "rh"         { $ouPath = "OU=RH,$ouBaseMatriz" }
+            "vendas"     { $ouPath = "OU=Vendas,$ouBaseMatriz" }
+            default      { $ouPath = "OU=Geral,$ouBaseMatriz" }
+        }
+    }
+    Write-Host "A máquina será ingressada na seguinte OU: $ouPath"
+    Write-Host "Solicitando credenciais do técnico de TI..."
+    $credential = Get-Credential -Message "Forneça as credenciais de administrador do domínio para ingressar a máquina '$ComputerNameToJoin'"
+    if (-not $credential) { throw "Operação cancelada pelo usuário. Nenhuma credencial foi fornecida." }
+    Write-Host "Tentando ingressar a máquina '$ComputerNameToJoin' no domínio '$DomainName'..."
+    Add-Computer -DomainName $DomainName -Credential $credential -OUPath $ouPath -Force -ErrorAction Stop
+    Write-Host "SUCESSO: Máquina ingressada no domínio com sucesso."
+    exit 0
+} catch {
+    $errorMessage = "ERRO FATAL NA FASE DE INGRESSO: $($_.Exception.Message)"
+    Write-Error $errorMessage
+    exit 1
+}

--- a/DeploymentShare$/Scripts/Invoke-WindowsUpdate.ps1
+++ b/DeploymentShare$/Scripts/Invoke-WindowsUpdate.ps1
@@ -1,0 +1,40 @@
+[CmdletBinding()]
+param()
+
+Write-Host "Verificando a presença do módulo PSWindowsUpdate, a ferramenta para automação do Windows Update..."
+try {
+    if (-not (Get-Module -ListAvailable -Name PSWindowsUpdate)) {
+        Write-Host "Módulo não encontrado. Tentando instalar a partir da Galeria do PowerShell..."
+        Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -ErrorAction Stop
+        Install-Module -Name PSWindowsUpdate -Force -AcceptLicense -Confirm:$false -ErrorAction Stop
+        Write-Host "Módulo PSWindowsUpdate instalado com sucesso."
+    }
+    Import-Module PSWindowsUpdate -ErrorAction Stop
+    Write-Host "Módulo PSWindowsUpdate carregado e pronto para uso."
+} catch {
+    Write-Error "ERRO FATAL: Não foi possível instalar ou importar o módulo PSWindowsUpdate. Verifique a conexão com a internet. Erro: $($_.Exception.Message)"
+    exit 1
+}
+
+Write-Host "Iniciando busca por novas atualizações do Windows Update..."
+$ProgressPreference = 'SilentlyContinue'
+try {
+    $resultadoDaInstalacao = Get-WUInstall -MicrosoftUpdate -AcceptAll -IgnoreReboot -Verbose
+    if (-not $resultadoDaInstalacao) {
+        Write-Host "Nenhuma atualização nova foi encontrada. O sistema já está atualizado neste ciclo."
+        exit 0
+    }
+    $rebootNecessario = $resultadoDaInstalacao | Where-Object { $_.RebootRequired -eq $true }
+    if ($rebootNecessario) {
+        Write-Host "ATENÇÃO: Uma ou mais atualizações foram instaladas e uma REINICIALIZAÇÃO é necessária para continuar."
+        exit 3010
+    } else {
+        Write-Host "Sucesso. Todas as atualizações disponíveis foram instaladas e nenhuma reinicialização é necessária neste ciclo."
+        exit 0
+    }
+} catch {
+    Write-Error "ERRO FATAL: Falha durante o processo de instalação do Windows Update. Erro: $($_.Exception.Message)"
+    exit 1
+} finally {
+    $ProgressPreference = 'Continue'
+}

--- a/DeploymentShare$/Scripts/Manage-ComputerIdentity.ps1
+++ b/DeploymentShare$/Scripts/Manage-ComputerIdentity.ps1
@@ -1,0 +1,79 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [ValidateSet('GetNewName', 'GetExistingNames', 'ResetADObject')]
+    [string]$Mode,
+
+    [string]$PerfilId,
+
+    [string]$ComputerName,
+
+    [string]$ServidorDhcp = "seu-servidor-dhcp.dominio.local"
+)
+
+try {
+    switch ($Mode) {
+        'GetExistingNames' {
+            Write-Host "MODO: GetExistingNames | Perfil: $PerfilId"
+            if ([string]::IsNullOrWhiteSpace($PerfilId)) { throw "-PerfilId é obrigatório para este modo." }
+
+            $prefixo = ""
+            switch ($PerfilId) {
+                "matriz"      { $prefixo = "sepro"; break }
+                "filial_se"   { $prefixo = "se-se"; break }
+                default       { throw "PerfilId '$PerfilId' inválido para listar nomes." }
+            }
+            $computadores = Get-ADComputer -Filter "Name -like '$($prefixo)*'" | Select-Object -ExpandProperty Name | Sort-Object
+            if ($computadores) { return ($computadores -join [Environment]::NewLine) }
+            return ""
+        }
+        'GetNewName' {
+            Write-Host "MODO: GetNewName | Perfil: $PerfilId"
+            if ([string]::IsNullOrWhiteSpace($PerfilId)) { throw "-PerfilId é obrigatório para este modo." }
+
+            $prefixo = ""
+            switch ($PerfilId) {
+                "matriz"      { $prefixo = "sepro"; break }
+                "filial_se"   { $prefixo = "se-se"; break }
+                default       { throw "PerfilId '$PerfilId' inválido para gerar novo nome." }
+            }
+            $numerosPossiveis = 8..190
+            $numerosUsados = [System.Collections.Generic.List[int]]::new()
+            Get-ADComputer -Filter "Name -like '$($prefixo)*'" -ErrorAction SilentlyContinue | ForEach-Object {
+                if ($_.Name -match '\d+') { $numerosUsados.Add([int]$matches[0]) }
+            }
+            Get-DhcpServerv4Reservation -ComputerName $ServidorDhcp -ErrorAction SilentlyContinue | Where-Object { $_.Name -like "$($prefixo)*" } | ForEach-Object {
+                if ($_.Name -match '\d+') { $numerosUsados.Add([int]$matches[0]) }
+            }
+            $numerosUsadosUnicos = $numerosUsados | Sort-Object -Unique
+            $numerosLivres = Compare-Object $numerosPossiveis $numerosUsadosUnicos | Where-Object { $_.SideIndicator -eq '<=' }
+            $proximoNumero = $numerosLivres | Select-Object -ExpandProperty InputObject -First 1
+            if (-not $proximoNumero) { throw "Não há números disponíveis no range de 8 a 190 para o perfil '$PerfilId'." }
+            $novoNome = "{0}{1:D4}" -f $prefixo, $proximoNumero
+            return $novoNome
+        }
+        'ResetADObject' {
+            Write-Host "MODO: ResetADObject | Computador: $ComputerName"
+            if ([string]::IsNullOrWhiteSpace($ComputerName)) { throw "-ComputerName é obrigatório para o modo ResetADObject." }
+            try {
+                if (Get-DhcpServerv4Reservation -ComputerName $ServidorDhcp -Name $ComputerName -ErrorAction SilentlyContinue) {
+                    Remove-DhcpServerv4Reservation -ComputerName $ServidorDhcp -Name $ComputerName -Force
+                    Write-Host "Reserva DHCP para '$ComputerName' removida com sucesso."
+                }
+            } catch {
+                Write-Warning "AVISO: Não foi possível remover a reserva DHCP para '$ComputerName'. Erro: $($_.Exception.Message)"
+            }
+            if (Get-ADComputer -Identity $ComputerName -ErrorAction SilentlyContinue) {
+                Remove-ADComputer -Identity $ComputerName -Confirm:$false
+                Write-Host "Objeto do computador '$ComputerName' removido do Active Directory com sucesso."
+            } else {
+                Write-Warning "AVISO: O objeto do computador '$ComputerName' não foi encontrado no AD."
+            }
+            return "Success"
+        }
+    }
+}
+catch {
+    Write-Error "ERRO FATAL no script Manage-ComputerIdentity.ps1: $($_.Exception.Message)"
+    exit 1
+}

--- a/DeploymentShare$/Scripts/Set-HostsFile.ps1
+++ b/DeploymentShare$/Scripts/Set-HostsFile.ps1
@@ -1,0 +1,23 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$HostsFileName
+)
+
+try {
+    $sourcePath = "\\seu-servidor\DeploymentShare$\Config\Hosts\$HostsFileName"
+    $destinationPath = Join-Path -Path $env:SystemRoot -ChildPath "System32\drivers\etc\hosts"
+    Write-Host "Iniciando processo de configuração do arquivo hosts."
+    Write-Host "Origem: $sourcePath"
+    Write-Host "Destino: $destinationPath"
+    if (-not (Test-Path -Path $sourcePath -PathType Leaf)) { throw "Arquivo hosts de origem não encontrado em '$sourcePath'. Verifique o nome do arquivo e o compartilhamento." }
+    Write-Host "Arquivo de origem encontrado."
+    Write-Host "Copiando arquivo de origem para o destino, sobrescrevendo se necessário..."
+    Copy-Item -Path $sourcePath -Destination $destinationPath -Force -ErrorAction Stop
+    Write-Host "Arquivo hosts configurado com sucesso."
+    exit 0
+} catch {
+    $errorMessage = "ERRO FATAL ao configurar o arquivo hosts: $($_.Exception.Message)"
+    Write-Error $errorMessage
+    exit 1
+}

--- a/DeploymentShare$/Scripts/Test-DriverStatus.ps1
+++ b/DeploymentShare$/Scripts/Test-DriverStatus.ps1
@@ -1,0 +1,20 @@
+[CmdletBinding()]
+param()
+
+Write-Host "Iniciando verificação de status de drivers no Gerenciador de Dispositivos..."
+try {
+    $dispositivosComProblema = Get-PnpDevice | Where-Object { $_.Status -ne 'OK' }
+    if ($null -eq $dispositivosComProblema) {
+        Write-Host "SUCESSO: Verificação concluída. Nenhum dispositivo com problema foi encontrado."
+        Write-Host "Todos os drivers parecem estar instalados e funcionando corretamente."
+        exit 0
+    } else {
+        Write-Warning "AVISO: Um ou mais dispositivos com problemas foram encontrados."
+        $dispositivosComProblema | Format-Table -Property Name, Status, Problem, ProblemDescription -AutoSize
+        exit 1
+    }
+} catch {
+    $errorMessage = "ERRO FATAL ao tentar verificar os drivers: $($_.Exception.Message)"
+    Write-Error $errorMessage
+    exit 99
+}


### PR DESCRIPTION
## Summary
- expand `DeploymentShare$` contents with Applications, Config, and Scripts folders
- add sample installers and VPN configuration
- update `master_config.json` and `matriz_ti.json`
- add example profile `matriz_financeiro.json`
- include PowerShell automation scripts used by provisioning

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c37c281f48328864bd2e815a2bb1e