### PR TITLE
Fix Program compile references

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Windows.Forms;
+
 namespace INSTALADOR_SOFTWARE_SE
 {
     /// <summary>
@@ -26,5 +29,4 @@ namespace INSTALADOR_SOFTWARE_SE
             // A aplicação permanecerá em execução, respondendo a eventos (cliques, etc.), até que este formulário seja fechado.
             Application.Run(formularioPrincipal);
         }
-    }
-}
+    }}


### PR DESCRIPTION
## Summary
- add missing System and Forms using statements in Program.cs

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686e9ee5ff988328be8a2a164f318d5d