### PR TITLE
Fix duplicate compile items

### DIFF
--- a/INSTALADOR-SOFTWARE-SE.csproj
+++ b/INSTALADOR-SOFTWARE-SE.csproj
@@ -5,8 +5,8 @@
     <UseWindowsForms>true</UseWindowsForms>
     <RootNamespace>INSTALADOR_SOFTWARE_SE</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <!-- Avoid including *.cs files twice -->
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <!-- Disable default item inclusion to avoid duplicate Compile entries -->
+    <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
   <!-- Explicitly include source files when default items are disabled -->


### PR DESCRIPTION
## Summary
- remove default item inclusion to avoid duplicate compile entries

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eaf5f98888328aa1818b082cd29b0