### PR TITLE
Fix comparison operator usage in Fase2_Identidade

### DIFF
--- a/Fases/Fase2_Identidade.cs
+++ b/Fases/Fase2_Identidade.cs
@@ -49,7 +49,10 @@ namespace INSTALADOR_SOFTWARE_SE.Fases
                 string modoNomenclatura = _estadoAtual["ModoNomenclatura"];
 
                 // --- BIFURCAÇÃO DA LÓGICA: MÁQUINA NOVA VS. REFORMATAÇÃO ---
-                if (modoNomenclatura == "ManterExistente")
+                if (string.Equals(
+                        modoNomenclatura,
+                        "ManterExistente",
+                        StringComparison.OrdinalIgnoreCase))
                 {
                     string nomeParaManter = _estadoAtual["NomeComputadorSelecionado"];
                     _logCallback($"Modo de reformatação selecionado para a máquina: {nomeParaManter}.");


### PR DESCRIPTION
## Summary
- fix equality check for naming mode in `Fase2_Identidade`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb5bcd2fc8328b35232b1a9719bc5